### PR TITLE
Add sign up wording to login flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -261,8 +261,8 @@
                 </button>
                 <!-- Authentication Button -->
                 <div id="authSection">
-                    <button id="signInBtn" onclick="handleSignIn()" class="hidden px-3 py-1 rounded-lg bg-blue-600 hover:bg-blue-700 transition text-sm font-medium">
-                        <i class="fas fa-sign-in-alt mr-1"></i>Sign In
+                    <button id="signInBtn" onclick="handleAuth()" class="hidden px-3 py-1 rounded-lg bg-blue-600 hover:bg-blue-700 transition text-sm font-medium">
+                        <i class="fas fa-sign-in-alt mr-1"></i>Sign In / Sign Up
                     </button>
                     <div id="userMenu" class="hidden relative">
                         <button onclick="toggleUserMenu()" class="flex items-center space-x-2 px-3 py-1 rounded-lg bg-white bg-opacity-20 hover:bg-opacity-30 transition">
@@ -3602,8 +3602,8 @@
             }
         }
 
-        // Handle sign in
-        function handleSignIn() {
+        // Handle sign in/sign up
+        function handleAuth() {
             window.location.href = '/login.html';
         }
 

--- a/public/login.html
+++ b/public/login.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <title>Domino Score – Login</title>
+  <title>Domino Score – Sign In / Sign Up</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <style>
     body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; display:flex; align-items:center; justify-content:center; min-height:100vh; background:#0b1220; color:#fff; }
@@ -16,9 +16,9 @@
 </head>
 <body>
   <div class="card">
-    <h1>Sign in to Domino Score</h1>
-    <button class="google" id="googleBtn">Continue with Google</button>
-    <div class="muted">You’ll be redirected back to the app after login.</div>
+    <h1>Sign In / Sign Up to Domino Score</h1>
+    <button class="google" id="googleBtn">Sign In / Sign Up with Google</button>
+    <div class="muted">You’ll be redirected back to the app after signing in or signing up.</div>
     <div class="err" id="err"></div>
   </div>
 


### PR DESCRIPTION
## Summary
- Update login page to show "Sign In / Sign Up" with Google and adjusted description
- Rename auth button and handler in index to reflect sign in/sign up

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b099d4e2288326bb9947d0a2da3e40