### PR TITLE
Ensure auth buttons display before Supabase init

### DIFF
--- a/index.html
+++ b/index.html
@@ -3786,6 +3786,7 @@
         }
 
         // Initialize authentication on app start
+        updateAuthUI();
         initAuth();
     </script>
 </body>


### PR DESCRIPTION
## Summary
- render sign-in/sign-out UI before attempting to initialize Supabase auth

## Testing
- `npm test` (fails: Error: no test specified)

------
https://chatgpt.com/codex/tasks/task_e_68b317809ca883268d99713dd4ef2265