### PR TITLE
fix(api): Use correct environment variables for Supabase client

### DIFF
--- a/api/stripe-webhook.ts
+++ b/api/stripe-webhook.ts
@@ -10,7 +10,7 @@ export const config = {
 };
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, { apiVersion: '2024-06-20' });
-const supabase = createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE!);
+const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE!);
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'POST') return res.status(405).end('Method Not Allowed');


### PR DESCRIPTION
In the `stripe-webhook` serverless function, the Supabase client was being initialized with `process.env.SUPABASE_URL`. However, the environment variable defined in the project's `.env` file is `NEXT_PUBLIC_SUPABASE_URL`.

This commit updates the `createClient` call to use `process.env.NEXT_PUBLIC_SUPABASE_URL` to ensure consistency with the defined environment variables.

The code continues to use `process.env.SUPABASE_SERVICE_ROLE`, which is the correct and secure way to authenticate for a server-side webhook that needs to write to the database. The user has been instructed to create a `.env.local` file and provide this secret.