### PR TITLE
Require authentication and add email login

### DIFF
--- a/index.html
+++ b/index.html
@@ -3563,21 +3563,23 @@
                 supabase.auth.onAuthStateChange((event, session) => {
                     console.log('Auth state changed:', event, session?.user?.email);
                     currentUser = session?.user || null;
-                    updateAuthUI();
-                    
-                    if (currentUser) {
-                        loadUserBilling();
+                    if (!currentUser) {
+                        window.location.href = '/login.html';
+                        return;
                     }
+                    updateAuthUI();
+                    loadUserBilling();
                 });
 
                 // Check current session
                 const { data: { session } } = await supabase.auth.getSession();
                 currentUser = session?.user || null;
-                updateAuthUI();
-                
-                if (currentUser) {
-                    loadUserBilling();
+                if (!currentUser) {
+                    window.location.href = '/login.html';
+                    return;
                 }
+                updateAuthUI();
+                loadUserBilling();
 
             } catch (error) {
                 console.error('Failed to initialize auth:', error);
@@ -3611,12 +3613,8 @@
         async function handleSignOut() {
             if (supabase) {
                 await supabase.auth.signOut();
-                currentUser = null;
-                userBilling = null;
-                updateAuthUI();
-                updateBillingUI();
-                showToast('Signed out successfully');
             }
+            window.location.href = '/login.html';
         }
 
         // Toggle user menu dropdown

--- a/public/login.html
+++ b/public/login.html
@@ -10,6 +10,8 @@
     h1 { font-size:20px; margin:0 0 12px }
     button { width:100%; padding:12px 16px; border-radius:10px; border:0; cursor:pointer; font-weight:600; }
     .google { background:#fff; color:#111827; }
+    .email { background:#3b82f6; color:#fff; margin-top:8px; }
+    input { width:100%; padding:12px 16px; border-radius:10px; border:0; margin-top:16px; background:#1e293b; color:#fff; }
     .muted { color:#94a3b8; font-size:12px; margin-top:10px; text-align:center }
     .err { color:#fca5a5; margin-top:12px; min-height:20px }
   </style>
@@ -18,6 +20,9 @@
   <div class="card">
     <h1>Sign in to Domino Score</h1>
     <button class="google" id="googleBtn">Continue with Google</button>
+    <div style="margin:16px 0; text-align:center; color:#94a3b8;">or</div>
+    <input type="email" id="emailInput" placeholder="Email address" />
+    <button class="email" id="emailBtn">Continue with Email</button>
     <div class="muted">You’ll be redirected back to the app after login.</div>
     <div class="err" id="err"></div>
   </div>
@@ -26,7 +31,9 @@
     import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 
     const errEl = document.getElementById('err');
-    const btn = document.getElementById('googleBtn');
+    const googleBtn = document.getElementById('googleBtn');
+    const emailBtn = document.getElementById('emailBtn');
+    const emailInput = document.getElementById('emailInput');
 
     async function getEnv() {
       const r = await fetch('/api/public-env');
@@ -39,10 +46,25 @@
         const { supabaseUrl, supabaseAnonKey } = await getEnv();
         const supabase = createClient(supabaseUrl, supabaseAnonKey, { auth: { persistSession: true, autoRefreshToken: true } });
 
-        btn.onclick = async () => {
+        googleBtn.onclick = async () => {
           errEl.textContent = '';
           const { error } = await supabase.auth.signInWithOAuth({ provider: 'google' });
           if (error) errEl.textContent = error.message;
+        };
+
+        emailBtn.onclick = async () => {
+          errEl.textContent = '';
+          const email = emailInput.value;
+          if (!email) {
+            errEl.textContent = 'Please enter your email';
+            return;
+          }
+          const { error } = await supabase.auth.signInWithOtp({ email, options: { emailRedirectTo: window.location.origin } });
+          if (error) {
+            errEl.textContent = error.message;
+          } else {
+            errEl.textContent = 'Check your email for the login link.';
+          }
         };
       } catch (e) {
         errEl.textContent = (e && e.message) ? e.message : 'Failed to initialize auth.';


### PR DESCRIPTION
## Summary
- add email-based magic link login alongside Google OAuth
- force users to sign in before accessing the app

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f2e801508326b6b5b61dabf6edff