### PR TITLE
Handle missing env API gracefully on login

### DIFF
--- a/public/login.html
+++ b/public/login.html
@@ -36,12 +36,12 @@
     const btn = document.getElementById('googleBtn');
 
     async function getEnv() {
-      try {
-        const r = await fetch('/api/public-env');
-        if (r.ok) return r.json();
-      } catch (e) {
-        // ignore and try fallback
-      }
+        try {
+          const r = await fetch('/api/public-env');
+          if (r.ok) return await r.json();
+        } catch (e) {
+          // ignore and try fallback
+        }
       const f = window.__PUBLIC_ENV__ || {};
       if (f.supabaseUrl && f.supabaseAnonKey) return f;
       throw new Error('Env not available');


### PR DESCRIPTION
## Summary
- handle JSON parse errors when fetching `/api/public-env` so login falls back to embedded env vars

## Testing
- `npm test` (fails: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68b72eecf49483268d1aba6e853bf9d8