### PR TITLE
fix: Handle non-JSON responses from API

### DIFF
--- a/index.html
+++ b/index.html
@@ -3584,13 +3584,16 @@
         async function initAuth() {
             try {
                 const response = await fetch('/api/public-env');
-                if (response.ok) {
+                const contentType = response.headers.get('content-type');
+
+                if (response.ok && contentType && contentType.includes('application/json')) {
                     const { supabaseUrl, supabaseAnonKey } = await response.json();
                     await initializeSupabase(supabaseUrl, supabaseAnonKey);
                     return;
                 }
-                // API not available; try client fallback
-                console.warn('Env API not available, using client fallback');
+
+                // API not available or returned non-JSON; try client fallback
+                console.warn('Env API not available or returned non-JSON, using client fallback');
                 const f = window.__PUBLIC_ENV__ || {};
                 if (f.supabaseUrl && f.supabaseAnonKey) {
                     await initializeSupabase(f.supabaseUrl, f.supabaseAnonKey);


### PR DESCRIPTION
The application was crashing with a JSON parsing error when the API returned an HTML response instead of JSON. This was happening because the code was not checking the Content-Type header before attempting to parse the response.

This change adds a check for the Content-Type header to ensure that the response is JSON before parsing it. This makes the application more robust and prevents it from crashing when the API returns an unexpected response.