### PR TITLE
style: darken login form for consistent UI

### DIFF
--- a/public/login.html
+++ b/public/login.html
@@ -15,10 +15,10 @@
     body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; display:flex; align-items:center; justify-content:center; min-height:100vh; background:#0b1220; color:#fff; }
     .card { background:#101827; padding:24px; border-radius:16px; width:100%; max-width:380px; box-shadow:0 10px 30px rgba(0,0,0,.4) }
     h1 { font-size:20px; margin:0 0 12px }
-    button { width:100%; padding:12px 16px; border-radius:10px; border:0; cursor:pointer; font-weight:600; }
+    button { width:100%; padding:12px 16px; border-radius:10px; border:0; cursor:pointer; font-weight:600; box-sizing:border-box; }
     .google { background:#1f2937; color:#fff; border:1px solid #374151; }
     .primary { background:#2563eb; color:#fff; margin-top:10px; }
-    input { width:100%; padding:12px 16px; border-radius:10px; border:1px solid #374151; margin-top:10px; background:#1f2937; color:#fff; }
+    input { width:100%; padding:12px 16px; border-radius:10px; border:1px solid #374151; margin-top:10px; background:#1f2937; color:#fff; box-sizing:border-box; }
     .muted { color:#94a3b8; font-size:12px; margin-top:10px; text-align:center }
     .muted a { color:#93c5fd; text-decoration:underline; font-weight:500; }
     .err { color:#fca5a5; margin-top:12px; min-height:20px }

--- a/public/login.html
+++ b/public/login.html
@@ -16,10 +16,11 @@
     .card { background:#101827; padding:24px; border-radius:16px; width:100%; max-width:380px; box-shadow:0 10px 30px rgba(0,0,0,.4) }
     h1 { font-size:20px; margin:0 0 12px }
     button { width:100%; padding:12px 16px; border-radius:10px; border:0; cursor:pointer; font-weight:600; }
-    .google { background:#fff; color:#111827; }
+    .google { background:#1f2937; color:#fff; border:1px solid #374151; }
     .primary { background:#2563eb; color:#fff; margin-top:10px; }
-    input { width:100%; padding:12px 16px; border-radius:10px; border:1px solid #1f2937; margin-top:10px; color:#111827; }
+    input { width:100%; padding:12px 16px; border-radius:10px; border:1px solid #374151; margin-top:10px; background:#1f2937; color:#fff; }
     .muted { color:#94a3b8; font-size:12px; margin-top:10px; text-align:center }
+    .muted a { color:#93c5fd; text-decoration:underline; font-weight:500; }
     .err { color:#fca5a5; margin-top:12px; min-height:20px }
     .hidden { display:none; }
   </style>


### PR DESCRIPTION
## Summary
- Darken Google button and form inputs for cohesive dark theme
- Highlight sign-up links for better visibility

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b744a82c588326a7455c0bcaed1c7c