### PR TITLE
Sync players and teams with Supabase

### DIFF
--- a/api/users/profile.ts
+++ b/api/users/profile.ts
@@ -41,6 +41,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           full_name: null,
           email: user.email,
           avatar_url: null,
+          players: [],
+          teams: [],
           created_at: user.created_at,
           updated_at: user.created_at,
         }
@@ -48,7 +50,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
     } else if (req.method === 'PUT') {
       // Update user profile
-      const { username, fullName, avatarUrl } = req.body;
+      const { username, fullName, avatarUrl, players, teams } = req.body;
 
       const updateData: any = {
         updated_at: new Date().toISOString(),
@@ -57,6 +59,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       if (username !== undefined) updateData.username = username;
       if (fullName !== undefined) updateData.full_name = fullName;
       if (avatarUrl !== undefined) updateData.avatar_url = avatarUrl;
+      if (players !== undefined) updateData.players = players;
+      if (teams !== undefined) updateData.teams = teams;
 
       const { data: profile, error } = await supabase
         .from('user_profiles')

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -17,6 +17,8 @@ CREATE TABLE IF NOT EXISTS user_profiles (
   full_name TEXT,
   email TEXT,
   avatar_url TEXT,
+  players JSONB DEFAULT '[]'::jsonb,
+  teams JSONB DEFAULT '[]'::jsonb,
   created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );

--- a/index.html
+++ b/index.html
@@ -1263,14 +1263,16 @@
                     localStorage.removeItem('dominoGames');
                     localStorage.removeItem('dominoAchievements');
                     localStorage.removeItem('dominoStreaks');
-                    
+
                     players = [];
                     teams = [];
                     games = [];
                     achievements = {};
                     streaks = {};
                     currentGame = null;
-                    
+
+                    savePlayersAndTeams();
+
                     Object.values(chartInstances).forEach(chart => {
                         if (chart) chart.destroy();
                     });
@@ -2671,6 +2673,7 @@
                 const newPlayer = { id: Date.now().toString(), name: playerName };
                 players.push(newPlayer);
                 localStorage.setItem('dominoPlayers', JSON.stringify(players));
+                savePlayersAndTeams();
             }
         }
 
@@ -2686,10 +2689,12 @@
                     if (isPlayerInTeam) {
                         teams = teams.filter(team => team.player1 !== playerToDelete.name && team.player2 !== playerToDelete.name);
                         localStorage.setItem('dominoTeams', JSON.stringify(teams));
+                        savePlayersAndTeams();
                     }
 
                     players = players.filter(p => p.id !== playerId);
                     localStorage.setItem('dominoPlayers', JSON.stringify(players));
+                    savePlayersAndTeams();
                     loadPlayers();
                     if (currentSection === 'teams') loadTeams();
                     showToast(`${playerToDelete.name} has been deleted.`);
@@ -2790,6 +2795,7 @@
                 };
                 teams.push(newTeam);
                 localStorage.setItem('dominoTeams', JSON.stringify(teams));
+                savePlayersAndTeams();
                 return newTeam;
             }
         }
@@ -2801,6 +2807,7 @@
                 () => {
                     teams = teams.filter(t => t.id !== teamId);
                     localStorage.setItem('dominoTeams', JSON.stringify(teams));
+                    savePlayersAndTeams();
                     loadTeams();
                     showToast('Team deleted successfully.');
                 }
@@ -3564,6 +3571,7 @@
                     updateAuthUI();
                     if (currentUser) {
                         loadUserBilling();
+                        syncPlayersAndTeams();
                     }
                 });
 
@@ -3573,6 +3581,7 @@
                 updateAuthUI();
                 if (currentUser) {
                     loadUserBilling();
+                    syncPlayersAndTeams();
                 }
             } catch (e) {
                 console.error('Failed to set up Supabase:', e);
@@ -3683,6 +3692,51 @@
                 updateBillingUI();
             } catch (error) {
                 console.error('Failed to load billing:', error);
+            }
+        }
+
+        // Sync players and teams with Supabase
+        async function syncPlayersAndTeams() {
+            if (!supabase || !currentUser) return;
+            try {
+                const { data, error } = await supabase
+                    .from('user_profiles')
+                    .select('players, teams')
+                    .eq('user_id', currentUser.id)
+                    .maybeSingle();
+
+                if (error) {
+                    console.error('Error loading profile data:', error);
+                    return;
+                }
+
+                if (data?.players || data?.teams) {
+                    players = data.players || [];
+                    teams = data.teams || [];
+                    localStorage.setItem('dominoPlayers', JSON.stringify(players));
+                    localStorage.setItem('dominoTeams', JSON.stringify(teams));
+                    refreshAllData();
+                } else if (players.length || teams.length) {
+                    await savePlayersAndTeams();
+                }
+            } catch (e) {
+                console.error('Failed to sync players/teams:', e);
+            }
+        }
+
+        async function savePlayersAndTeams() {
+            if (!supabase || !currentUser) return;
+            try {
+                await supabase
+                    .from('user_profiles')
+                    .upsert({
+                        user_id: currentUser.id,
+                        players,
+                        teams,
+                        updated_at: new Date().toISOString()
+                    }, { onConflict: 'user_id' });
+            } catch (e) {
+                console.error('Failed to save players/teams:', e);
             }
         }
 


### PR DESCRIPTION
## Summary
- add players and teams fields to user_profiles schema
- expose players/teams in profile API
- sync players and teams with Supabase from the frontend

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b74a7ea5e8832698f85d4189b3315d