### PR TITLE
Fix section navigation data loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -1283,27 +1283,6 @@
             );
         }
 
-        // Navigation
-        function showSection(section) {
-            document.querySelectorAll('.section').forEach(s => s.classList.add('hidden'));
-            document.getElementById(section + 'Section').classList.remove('hidden');
-            currentSection = section;
-            
-            document.querySelectorAll('.nav-btn, .mobile-nav-btn').forEach(btn => {
-                btn.classList.remove('active');
-            });
-            document.querySelectorAll(`[data-section="${section}"]`).forEach(btn => {
-                btn.classList.add('active');
-            });
-            
-            if (section === 'home') loadHome();
-            else if (section === 'players') loadPlayers();
-            else if (section === 'teams') loadTeams();
-            else if (section === 'leaderboard') loadLeaderboard();
-            else if (section === 'live') loadLiveSection();
-            else if (section === 'history') showHistory('daily');
-        }
-
         function refreshAllData() {
             loadTodaysPerformance();
             loadRecentGames();
@@ -3812,6 +3791,16 @@
             // Load section-specific data
             if (sectionName === 'home') {
                 refreshAllData();
+            } else if (sectionName === 'players') {
+                loadPlayers();
+            } else if (sectionName === 'teams') {
+                loadTeams();
+            } else if (sectionName === 'leaderboard') {
+                loadLeaderboard();
+            } else if (sectionName === 'live') {
+                loadLiveSection();
+            } else if (sectionName === 'history') {
+                showHistory('daily');
             } else if (sectionName === 'billing' && currentUser) {
                 loadUserBilling();
             }


### PR DESCRIPTION
## Summary
- Remove duplicate `showSection` implementation
- Load section data when navigating between pages

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b75127242c8326a06fe5cf871fb05b