### PR TITLE
fix: enable ESM and correct MCP handlers

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,5 +17,5 @@
     "stripe": "^18.4.0"
   },
   "description": "",
-  "type": "commonjs"
+  "type": "module"
 }

--- a/supabase-mcp-server.js
+++ b/supabase-mcp-server.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import 'dotenv/config';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { CallToolRequestSchema, ErrorCode, ListToolsRequestSchema, McpError } from '@modelcontextprotocol/sdk/types.js';
@@ -36,7 +37,7 @@ class SupabaseMCPServer {
 
   setupToolHandlers() {
     // Database Query Tool
-    this.server.setRequestHandler('tools/call', async (request) => {
+    this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
       const { name, arguments: args } = request.params;
 
       switch (name) {
@@ -75,7 +76,7 @@ class SupabaseMCPServer {
 
   setupRequestHandlers() {
     // List available tools
-    this.server.setRequestHandler('tools/list', async () => {
+    this.server.setRequestHandler(ListToolsRequestSchema, async () => {
       return {
         tools: [
           {

--- a/supabase-mcp-server.mjs
+++ b/supabase-mcp-server.mjs
@@ -3,7 +3,7 @@
 import 'dotenv/config';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+import { CallToolRequestSchema, ErrorCode, ListToolsRequestSchema, McpError } from '@modelcontextprotocol/sdk/types.js';
 import { createClient } from '@supabase/supabase-js';
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -28,7 +28,7 @@ class SupabaseMCPServer {
   }
 
   setupToolHandlers() {
-    this.server.setRequestHandler('tools/call', async (request) => {
+    this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
       const { name, arguments: args } = request.params;
 
       switch (name) {
@@ -66,7 +66,7 @@ class SupabaseMCPServer {
   }
 
   setupRequestHandlers() {
-    this.server.setRequestHandler('tools/list', async () => {
+    this.server.setRequestHandler(ListToolsRequestSchema, async () => {
       return {
         tools: [
           {


### PR DESCRIPTION
## Summary
- enable ES module support by setting package type
- load environment variables and use schema-aware request handlers

## Testing
- `npm test` *(fails: Error: no test specified)*
- `NEXT_PUBLIC_SUPABASE_URL=https://example.com SUPABASE_SERVICE_ROLE=bar timeout 5 node supabase-mcp-server.js`

------
https://chatgpt.com/codex/tasks/task_e_68b7a6be1b8c8326b957661c0db0e97e