### PR TITLE
Fix: Refactor login to use backend API endpoint

### DIFF
--- a/public/login.html
+++ b/public/login.html
@@ -4,13 +4,6 @@
   <meta charset="utf-8" />
   <title>Domino Score – Login</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <script>
-    // Public client-side fallback for local testing
-    window.__PUBLIC_ENV__ = {
-      supabaseUrl: 'https://vsjdinqfxazedrjigssx.supabase.co',
-      supabaseAnonKey: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InZzamRpbnFmeGF6ZWRyamlnc3N4Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTYyMzE4OTksImV4cCI6MjA3MTgwNzg5OX0.hz7sZULnVNbqDEZQqSyTvPuK8d7n8QeD0U_TyDVEDTs'
-    };
-  </script>
   <style>
     body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; display:flex; align-items:center; justify-content:center; min-height:100vh; background:#0b1220; color:#fff; }
     .card { background:#101827; padding:24px; border-radius:16px; width:100%; max-width:380px; box-shadow:0 10px 30px rgba(0,0,0,.4) }
@@ -62,15 +55,9 @@
     toSignIn.onclick = () => { signUpView.classList.add('hidden'); signInView.classList.remove('hidden'); errEl.textContent = ''; };
 
     async function getEnv() {
-      try {
-        const r = await fetch('/api/public-env');
-        if (r.ok) return r.json();
-      } catch (e) {
-        // ignore and try fallback
-      }
-      const f = window.__PUBLIC_ENV__ || {};
-      if (f.supabaseUrl && f.supabaseAnonKey) return f;
-      throw new Error('Env not available');
+      const r = await fetch('/api/public-env');
+      if (r.ok) return r.json();
+      throw new Error('Failed to fetch environment variables');
     }
 
     async function init() {
@@ -91,10 +78,22 @@
           errEl.textContent = '';
           const email = document.getElementById('email').value.trim();
           const password = document.getElementById('password').value;
-          const { error } = await supabase.auth.signInWithPassword({ email, password });
-          if (error) { errEl.textContent = error.message; return; }
-          const target = (location.protocol === 'file:') ? '../index.html' : '/index.html';
-          window.location.href = target;
+          try {
+            const r = await fetch('/api/auth/login', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ email, password })
+            });
+            const data = await r.json();
+            if (!r.ok) {
+              errEl.textContent = data.error || 'Login failed';
+              return;
+            }
+            const target = (location.protocol === 'file:') ? '../index.html' : '/index.html';
+            window.location.href = target;
+          } catch (e) {
+            errEl.textContent = 'Login failed';
+          }
         };
 
         emailSignupBtn.onclick = async () => {


### PR DESCRIPTION
This commit fixes the login issue on mobile devices by refactoring the email/password login process to use the `/api/auth/login` backend endpoint instead of the client-side Supabase SDK.

The original implementation relied on a client-side fetch to `/api/public-env` to get the Supabase credentials. This was failing in the Vercel production environment, causing the application to fall back to hardcoded local testing credentials, which resulted in a "server can't be reached" error.

The new implementation:
- Uses the `/api/auth/login` endpoint, which is the documented and more secure way to handle authentication.
- Removes the fragile client-side environment variable fetching for the email/password login.
- Removes the hardcoded `window.__PUBLIC_ENV__` fallback, which was masking the production error.

The Google OAuth login still uses the client-side SDK and requires the `/api/public-env` endpoint, but the primary email/password login flow is now more robust and secure.