### PR TITLE
The sign-in page was producing a 404 error. This was caused by two is…

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,5 +17,5 @@
     "stripe": "^18.4.0"
   },
   "description": "",
-  "type": "commonjs"
+  "type": "module"
 }

--- a/public/login.html
+++ b/public/login.html
@@ -91,10 +91,21 @@
           errEl.textContent = '';
           const email = document.getElementById('email').value.trim();
           const password = document.getElementById('password').value;
-          const { error } = await supabase.auth.signInWithPassword({ email, password });
-          if (error) { errEl.textContent = error.message; return; }
-          const target = (location.protocol === 'file:') ? '../index.html' : '/index.html';
-          window.location.href = target;
+          try {
+            const r = await fetch('/api/auth/login', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ email, password })
+            });
+            const data = await r.json();
+            if (!r.ok) { errEl.textContent = data.error || 'Login failed'; return; }
+            const { error } = await supabase.auth.setSession(data.session);
+            if (error) { errEl.textContent = error.message; return; }
+            const target = (location.protocol === 'file:') ? '../index.html' : '/index.html';
+            window.location.href = target;
+          } catch (e) {
+            errEl.textContent = 'Login failed';
+          }
         };
 
         emailSignupBtn.onclick = async () => {


### PR DESCRIPTION
…sues.

First, the serverless functions were not being served correctly due to a module type mismatch in `package.json`. The API files use ES Module syntax, but the project was configured for CommonJS. This was fixed by changing the type to "module".

Second, the email sign-in form was using the client-side Supabase library directly, while the sign-up form was using a server-side API endpoint. This was made consistent by updating the sign-in form to call the `/api/auth/login` endpoint.

These two changes together resolve the 404 error and improve the application's architecture.