### PR TITLE
Fix sign-in navigation with relative paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -3634,7 +3634,7 @@
         // Handle sign in
         function handleSignIn() {
             // Redirect to login page
-            window.location.href = '/login.html';
+            window.location.href = 'login.html';
         }
 
         // Handle sign out

--- a/login.html
+++ b/login.html
@@ -58,14 +58,14 @@
         <div class="mt-6 text-center">
             <p class="text-gray-600">
                 Don't have an account?
-                <a href="/signup.html" class="text-purple-600 hover:text-purple-700 font-medium">
+                <a href="signup.html" class="text-purple-600 hover:text-purple-700 font-medium">
                     Sign up here
                 </a>
             </p>
         </div>
 
         <div class="mt-4 text-center">
-            <a href="/" class="text-gray-500 hover:text-gray-700 text-sm">
+            <a href="index.html" class="text-gray-500 hover:text-gray-700 text-sm">
                 <i class="fas fa-arrow-left mr-1"></i>
                 Back to Home
             </a>
@@ -149,7 +149,7 @@
                 
                 // Redirect to main app after short delay
                 setTimeout(() => {
-                    window.location.href = '/';
+                    window.location.href = 'index.html';
                 }, 1000);
 
             } catch (error) {

--- a/signup.html
+++ b/signup.html
@@ -85,14 +85,14 @@
         <div class="mt-6 text-center">
             <p class="text-gray-600">
                 Already have an account?
-                <a href="/login.html" class="text-purple-600 hover:text-purple-700 font-medium">
+                <a href="login.html" class="text-purple-600 hover:text-purple-700 font-medium">
                     Sign in here
                 </a>
             </p>
         </div>
 
         <div class="mt-4 text-center">
-            <a href="/" class="text-gray-500 hover:text-gray-700 text-sm">
+            <a href="index.html" class="text-gray-500 hover:text-gray-700 text-sm">
                 <i class="fas fa-arrow-left mr-1"></i>
                 Back to Home
             </a>
@@ -200,7 +200,7 @@
                     
                     // Redirect to main app after short delay
                     setTimeout(() => {
-                        window.location.href = '/';
+                        window.location.href = 'index.html';
                     }, 2000);
                 }
 


### PR DESCRIPTION
## Summary
- Use relative path when redirecting to login page from main screen
- Make login and signup pages use relative URLs for navigation and post-auth redirects

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b874ab780c8326896bc3066dea0452