### PR TITLE
style: apply dark theme to sign-in page

### DIFF
--- a/login.html
+++ b/login.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="dark">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -13,38 +13,37 @@
         }
         
         .domino-card {
-            background: white;
             border-radius: 15px;
             box-shadow: 0 8px 25px rgba(0,0,0,0.15);
         }
     </style>
 </head>
 <body class="domino-bg min-h-screen flex items-center justify-center p-4">
-    <div class="domino-card w-full max-w-md p-8">
+    <div class="domino-card w-full max-w-md p-8 bg-white dark:bg-gray-800">
         <div class="text-center mb-8">
-            <h1 class="text-3xl font-bold text-gray-800 mb-2">
+            <h1 class="text-3xl font-bold text-gray-800 dark:text-gray-100 mb-2">
                 <i class="fas fa-dice-d6 text-purple-600 mr-2"></i>
                 Domino Score
             </h1>
-            <p class="text-gray-600">Sign in to your account</p>
+            <p class="text-gray-600 dark:text-gray-300">Sign in to your account</p>
         </div>
 
         <form id="loginForm" class="space-y-6">
             <div>
-                <label for="email" class="block text-sm font-medium text-gray-700 mb-2">
+                <label for="email" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                     Email Address
                 </label>
                 <input type="email" id="email" name="email" required
-                    class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent transition duration-200"
+                    class="w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent transition duration-200 dark:bg-gray-700 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-400"
                     placeholder="Enter your email">
             </div>
 
             <div>
-                <label for="password" class="block text-sm font-medium text-gray-700 mb-2">
+                <label for="password" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                     Password
                 </label>
                 <input type="password" id="password" name="password" required
-                    class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent transition duration-200"
+                    class="w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent transition duration-200 dark:bg-gray-700 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-400"
                     placeholder="Enter your password">
             </div>
 
@@ -59,17 +58,17 @@
         <div class="mt-6 mb-6">
             <div class="relative">
                 <div class="absolute inset-0 flex items-center">
-                    <div class="w-full border-t border-gray-300"></div>
+                    <div class="w-full border-t border-gray-300 dark:border-gray-600"></div>
                 </div>
                 <div class="relative flex justify-center text-sm">
-                    <span class="px-2 bg-white text-gray-500">Or continue with</span>
+                    <span class="px-2 bg-white dark:bg-gray-800 text-gray-500 dark:text-gray-400">Or continue with</span>
                 </div>
             </div>
         </div>
 
         <!-- Google Sign-In Button -->
         <button id="googleSignInBtn" type="button"
-            class="w-full bg-white border border-gray-300 text-gray-700 py-3 px-4 rounded-lg hover:bg-gray-50 focus:ring-2 focus:ring-purple-500 focus:ring-offset-2 transition duration-200 font-medium flex items-center justify-center">
+            class="w-full bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 py-3 px-4 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600 focus:ring-2 focus:ring-purple-500 focus:ring-offset-2 transition duration-200 font-medium flex items-center justify-center">
             <svg class="w-5 h-5 mr-3" viewBox="0 0 24 24">
                 <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
                 <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
@@ -80,16 +79,16 @@
         </button>
 
         <div class="mt-6 text-center">
-            <p class="text-gray-600">
+            <p class="text-gray-600 dark:text-gray-400">
                 Don't have an account?
-                <a href="/signup.html" class="text-purple-600 hover:text-purple-700 font-medium">
+                <a href="/signup.html" class="text-purple-600 hover:text-purple-700 dark:text-purple-400 dark:hover:text-purple-300 font-medium">
                     Sign up here
                 </a>
             </p>
         </div>
 
         <div class="mt-4 text-center">
-            <a href="/" class="text-gray-500 hover:text-gray-700 text-sm">
+            <a href="/" class="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 text-sm">
                 <i class="fas fa-arrow-left mr-1"></i>
                 Back to Home
             </a>


### PR DESCRIPTION
## Summary
- enable dark mode styling for the sign-in page
- adjust input fields and buttons for dark theme compatibility
- refine divider and links to match dark palette

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b8802a51a48326974c48345abba2ad