### PR TITLE
Add dark theme styling to sign-in page

### DIFF
--- a/login.html
+++ b/login.html
@@ -7,44 +7,107 @@
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.4.0/css/all.min.css">
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+    <script>
+        const theme = localStorage.getItem('theme');
+        if (theme === 'dark') {
+            document.documentElement.classList.add('dark');
+        }
+    </script>
     <style>
         .domino-bg {
             background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
         }
-        
+
         .domino-card {
             background: white;
             border-radius: 15px;
             box-shadow: 0 8px 25px rgba(0,0,0,0.15);
         }
+
+        /* Dark mode styles */
+        .dark {
+            background-color: #1f2937;
+            color: #f3f4f6;
+        }
+
+        .dark body {
+            background-color: #1f2937;
+        }
+
+        .dark .domino-bg {
+            background: #1f2937;
+        }
+
+        .dark .domino-card {
+            background: #374151;
+            color: #f3f4f6;
+        }
+
+        .dark .text-gray-500 {
+            color: #9ca3af;
+        }
+
+        .dark .text-gray-600 {
+            color: #d1d5db;
+        }
+
+        .dark .text-gray-700 {
+            color: #e5e7eb;
+        }
+
+        .dark .text-gray-800 {
+            color: #f3f4f6;
+        }
+
+        .dark .border {
+            border-color: #4b5563;
+        }
+
+        .dark .border-gray-300 {
+            border-color: #4b5563;
+        }
+
+        .dark input {
+            background-color: #4b5563;
+            color: #f3f4f6;
+            border-color: #6b7280;
+        }
+
+        .dark input::placeholder {
+            color: #9ca3af;
+        }
+
+        .dark .bg-white {
+            background-color: #374151;
+        }
     </style>
 </head>
-<body class="domino-bg min-h-screen flex items-center justify-center p-4">
+<body class="domino-bg min-h-screen flex items-center justify-center p-4 transition-colors duration-300">
     <div class="domino-card w-full max-w-md p-8">
         <div class="text-center mb-8">
-            <h1 class="text-3xl font-bold text-gray-800 mb-2">
+            <h1 class="text-3xl font-bold text-gray-800 dark:text-gray-100 mb-2">
                 <i class="fas fa-dice-d6 text-purple-600 mr-2"></i>
                 Domino Score
             </h1>
-            <p class="text-gray-600">Sign in to your account</p>
+            <p class="text-gray-600 dark:text-gray-300">Sign in to your account</p>
         </div>
 
         <form id="loginForm" class="space-y-6">
             <div>
-                <label for="email" class="block text-sm font-medium text-gray-700 mb-2">
+                <label for="email" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                     Email Address
                 </label>
                 <input type="email" id="email" name="email" required
-                    class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent transition duration-200"
+                    class="w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent transition duration-200 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-300"
                     placeholder="Enter your email">
             </div>
 
             <div>
-                <label for="password" class="block text-sm font-medium text-gray-700 mb-2">
+                <label for="password" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                     Password
                 </label>
                 <input type="password" id="password" name="password" required
-                    class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent transition duration-200"
+                    class="w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent transition duration-200 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-300"
                     placeholder="Enter your password">
             </div>
 
@@ -59,17 +122,17 @@
         <div class="mt-6 mb-6">
             <div class="relative">
                 <div class="absolute inset-0 flex items-center">
-                    <div class="w-full border-t border-gray-300"></div>
+                    <div class="w-full border-t border-gray-300 dark:border-gray-600"></div>
                 </div>
                 <div class="relative flex justify-center text-sm">
-                    <span class="px-2 bg-white text-gray-500">Or continue with</span>
+                    <span class="px-2 bg-white dark:bg-gray-700 text-gray-500 dark:text-gray-400">Or continue with</span>
                 </div>
             </div>
         </div>
 
         <!-- Google Sign-In Button -->
         <button id="googleSignInBtn" type="button"
-            class="w-full bg-white border border-gray-300 text-gray-700 py-3 px-4 rounded-lg hover:bg-gray-50 focus:ring-2 focus:ring-purple-500 focus:ring-offset-2 transition duration-200 font-medium flex items-center justify-center">
+            class="w-full bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 py-3 px-4 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600 focus:ring-2 focus:ring-purple-500 focus:ring-offset-2 transition duration-200 font-medium flex items-center justify-center">
             <svg class="w-5 h-5 mr-3" viewBox="0 0 24 24">
                 <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
                 <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
@@ -80,16 +143,16 @@
         </button>
 
         <div class="mt-6 text-center">
-            <p class="text-gray-600">
+            <p class="text-gray-600 dark:text-gray-400">
                 Don't have an account?
-                <a href="/signup.html" class="text-purple-600 hover:text-purple-700 font-medium">
+                <a href="/signup.html" class="text-purple-600 hover:text-purple-700 dark:text-purple-400 dark:hover:text-purple-300 font-medium">
                     Sign up here
                 </a>
             </p>
         </div>
 
         <div class="mt-4 text-center">
-            <a href="/" class="text-gray-500 hover:text-gray-700 text-sm">
+            <a href="/" class="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 text-sm">
                 <i class="fas fa-arrow-left mr-1"></i>
                 Back to Home
             </a>


### PR DESCRIPTION
## Summary
- load saved theme and apply dark class on sign-in page
- add dark mode styles and update inputs, dividers, and buttons to match dark theme

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b8802a51a48326974c48345abba2ad