### PR TITLE
fix: robust supabase init on login

### DIFF
--- a/login.html
+++ b/login.html
@@ -218,17 +218,25 @@
         async function initSupabase() {
             try {
                 const response = await fetch('/api/public-env');
-                if (response.ok) {
+                const contentType = response.headers.get('content-type');
+
+                if (response.ok && contentType && contentType.includes('application/json')) {
                     const { supabaseUrl, supabaseAnonKey } = await response.json();
                     supabase = window.supabase.createClient(supabaseUrl, supabaseAnonKey);
-                } else {
-                    // Fallback to client-side config
-                    const config = window.__PUBLIC_ENV__ || {
-                        supabaseUrl: 'https://vsjdinqfxazedrjigssx.supabase.co',
-                        supabaseAnonKey: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InZzamRpbnFmeGF6ZWRyamlnc3N4Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTYyMzE4OTksImV4cCI6MjA3MTgwNzg5OX0.hz7sZULnVNbqDEZQqSyTvPuK8d7n8QeD0U_TyDVEDTs'
-                    };
-                    supabase = window.supabase.createClient(config.supabaseUrl, config.supabaseAnonKey);
+                    return;
                 }
+
+                console.warn('Env API not available or returned non-JSON, using client fallback');
+            } catch (error) {
+                console.warn('Env API fetch failed, using client fallback');
+            }
+
+            try {
+                const config = window.__PUBLIC_ENV__ || {
+                    supabaseUrl: 'https://vsjdinqfxazedrjigssx.supabase.co',
+                    supabaseAnonKey: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InZzamRpbnFmeGF6ZWRyamlnc3N4Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTYyMzE4OTksImV4cCI6MjA3MTgwNzg5OX0.hz7sZULnVNbqDEZQqSyTvPuK8d7n8QeD0U_TyDVEDTs'
+                };
+                supabase = window.supabase.createClient(config.supabaseUrl, config.supabaseAnonKey);
             } catch (error) {
                 console.error('Failed to initialize Supabase:', error);
                 showToast('Failed to initialize authentication', 'error');


### PR DESCRIPTION
## Summary
- handle non-JSON responses from `/api/public-env` when initializing Supabase
- fall back to client configuration to ensure sign-in works even when env API fails

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b892f092648326ad0136fd8292c25c