### PR TITLE
fix(login): Improve error handling when server is not running

### DIFF
--- a/login.html
+++ b/login.html
@@ -222,16 +222,13 @@
                     const { supabaseUrl, supabaseAnonKey } = await response.json();
                     supabase = window.supabase.createClient(supabaseUrl, supabaseAnonKey);
                 } else {
-                    // Fallback to client-side config
-                    const config = window.__PUBLIC_ENV__ || {
-                        supabaseUrl: 'https://vsjdinqfxazedrjigssx.supabase.co',
-                        supabaseAnonKey: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InZzamRpbnFmeGF6ZWRyamlnc3N4Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTYyMzE4OTksImV4cCI6MjA3MTgwNzg5OX0.hz7sZULnVNbqDEZQqSyTvPuK8d7n8QeD0U_TyDVEDTs'
-                    };
-                    supabase = window.supabase.createClient(config.supabaseUrl, config.supabaseAnonKey);
+                    const errorText = await response.text();
+                    console.error('Failed to fetch public env:', response.status, errorText);
+                    showToast('Error: Could not load app configuration from server.', 'error');
                 }
             } catch (error) {
                 console.error('Failed to initialize Supabase:', error);
-                showToast('Failed to initialize authentication', 'error');
+                showToast('Server not running? Run "npm run dev" and refresh.', 'error');
             }
         }
 


### PR DESCRIPTION
Removes hardcoded Supabase fallback credentials from login.html. This was a security risk and masked the real issue.

Adds clear error handling to the login page. If the frontend cannot connect to the backend API, it now displays a user-friendly error message instructing the user to start the server with "npm run dev".

This directly addresses the "localhost refused to connect" error reported by the user.