### PR TITLE
fix: align supabase env variables

### DIFF
--- a/api/teams/[id].ts
+++ b/api/teams/[id].ts
@@ -2,8 +2,8 @@ import { createClient } from '@supabase/supabase-js';
 import jwt from 'jsonwebtoken';
 
 const supabase = createClient(
-  process.env.SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE!
 );
 
 interface TeamUpdateRequest {

--- a/api/teams/[id]/members.ts
+++ b/api/teams/[id]/members.ts
@@ -2,8 +2,8 @@ import { createClient } from '@supabase/supabase-js';
 import jwt from 'jsonwebtoken';
 
 const supabase = createClient(
-  process.env.SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE!
 );
 
 interface AddMemberRequest {

--- a/api/teams/index.ts
+++ b/api/teams/index.ts
@@ -2,8 +2,8 @@ import { createClient } from '@supabase/supabase-js';
 import jwt from 'jsonwebtoken';
 
 const supabase = createClient(
-  process.env.SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE!
 );
 
 interface TeamCreateRequest {

--- a/tests/team-sync-test.js
+++ b/tests/team-sync-test.js
@@ -9,8 +9,9 @@ const { createClient } = require('@supabase/supabase-js');
 const jwt = require('jsonwebtoken');
 
 // Test configuration
-const SUPABASE_URL = process.env.SUPABASE_URL || 'your-supabase-url';
-const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || 'your-service-key';
+// Use the same environment variables used by the API routes
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL || 'your-supabase-url';
+const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE || 'your-service-key';
 const JWT_SECRET = process.env.SUPABASE_JWT_SECRET || 'your-jwt-secret';
 
 const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);


### PR DESCRIPTION
## Summary
- use consistent Supabase environment variables in team endpoints and tests

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bc345ad4208326862f444d39ee44fb