### PR TITLE
Fix navigation to reload leaderboard and other sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -1283,27 +1283,6 @@
             );
         }
 
-        // Navigation
-        function showSection(section) {
-            document.querySelectorAll('.section').forEach(s => s.classList.add('hidden'));
-            document.getElementById(section + 'Section').classList.remove('hidden');
-            currentSection = section;
-            
-            document.querySelectorAll('.nav-btn, .mobile-nav-btn').forEach(btn => {
-                btn.classList.remove('active');
-            });
-            document.querySelectorAll(`[data-section="${section}"]`).forEach(btn => {
-                btn.classList.add('active');
-            });
-            
-            if (section === 'home') loadHome();
-            else if (section === 'players') loadPlayers();
-            else if (section === 'teams') loadTeams();
-            else if (section === 'leaderboard') loadLeaderboard();
-            else if (section === 'live') loadLiveSection();
-            else if (section === 'history') showHistory('daily');
-        }
-
         function refreshAllData() {
             loadTodaysPerformance();
             loadRecentGames();
@@ -3854,7 +3833,17 @@
 
             // Load section-specific data
             if (sectionName === 'home') {
-                refreshAllData();
+                loadHome();
+            } else if (sectionName === 'players') {
+                loadPlayers();
+            } else if (sectionName === 'teams') {
+                loadTeams();
+            } else if (sectionName === 'leaderboard') {
+                loadLeaderboard();
+            } else if (sectionName === 'live') {
+                loadLiveSection();
+            } else if (sectionName === 'history') {
+                showHistory('daily');
             } else if (sectionName === 'billing' && currentUser) {
                 loadUserBilling();
             }


### PR DESCRIPTION
## Summary
- Ensure section navigation loads all expected content including players, teams, leaderboard, live games, and history.
- Consolidate navigation logic into a single `showSection` handler.

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node tests/team-sync-test.js` *(fails: Cannot find module '@supabase/supabase-js')*

------
https://chatgpt.com/codex/tasks/task_e_68bc3876db288326a0e5c7662ee447ba