### PR TITLE
Align account menu with dark mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -277,12 +277,12 @@
                             <span id="userName" class="text-sm font-medium max-w-20 truncate"></span>
                             <i class="fas fa-chevron-down text-xs"></i>
                         </button>
-                        <div id="userDropdown" class="hidden absolute right-0 mt-2 w-48 bg-white dark:bg-gray-800 rounded-lg shadow-lg border dark:border-gray-700 z-50">
+                        <div id="userDropdown" class="hidden absolute right-0 mt-2 w-48 domino-card border dark:border-gray-700 z-50">
                             <div class="py-2">
-                                <button onclick="showBilling()" class="w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700">
+                                <button onclick="showBilling()" class="w-full text-left px-4 py-2 text-sm text-gray-800 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700">
                                     <i class="fas fa-credit-card mr-2"></i>Billing
                                 </button>
-                                <button onclick="handleSignOut()" class="w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700">
+                                <button onclick="handleSignOut()" class="w-full text-left px-4 py-2 text-sm text-gray-800 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700">
                                     <i class="fas fa-sign-out-alt mr-2"></i>Sign Out
                                 </button>
                             </div>


### PR DESCRIPTION
## Summary
- style user dropdown with domino card so Billing and Sign Out match dark theme

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bc58bca6848326958c27884ded86b4