### PR TITLE
feat: Make dev server accessible on local network

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "_domino-score",
   "version": "1.0.0",
   "scripts": {
-    "dev": "vercel dev",
+    "dev": "vercel dev --listen 0.0.0.0:3000",
     "build": "echo \"Static build completed\"",
-    "start": "vercel dev",
+    "start": "vercel dev --listen 0.0.0.0:3000",
     "serve": "serve -s . -p 3000",
     "deploy": "vercel --prod",
     "preview": "vercel",


### PR DESCRIPTION
The Vercel development server, started with `vercel dev`, defaults to listening on `localhost`, which is not accessible from other devices on the network.

This change adds the `--listen 0.0.0.0:3000` flag to the `dev` and `start` scripts in `package.json`. This makes the development server listen on all network interfaces, allowing mobile devices on the same network to access it for testing.