### PR TITLE
fix: improve billing dark mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,13 +32,13 @@
         }
         
         .domino-card {
-            background: white;
+            background: #f9fafb;
             border-radius: 15px;
             box-shadow: 0 8px 25px rgba(0,0,0,0.15);
         }
-        
+
         .dark .domino-card {
-            background: #374151;
+            background: #1f2937 !important;
             color: #f3f4f6;
         }
         


### PR DESCRIPTION
## Summary
- enforce dark background for domino cards to avoid white billing section in dark mode

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bc70c19568832692aca8646c071c80