### PR TITLE
Improve billing section dark mode styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -749,11 +749,11 @@
         </div>
 
         <!-- Billing Section -->
-        <div id="billingSection" class="section hidden">
+        <div id="billingSection" class="section hidden dark:bg-gray-700 dark:text-white">
             <div class="max-w-4xl mx-auto">
                 <div class="mb-6">
                     <h2 class="text-2xl font-bold mb-2">Subscription & Billing</h2>
-                    <p class="text-gray-600 dark:text-gray-400">Manage your Domino Score Pro subscription</p>
+                    <p class="text-gray-600 dark:text-white">Manage your Domino Score Pro subscription</p>
                 </div>
 
                 <!-- Current Plan -->
@@ -763,11 +763,11 @@
                         <div class="flex items-center justify-between">
                             <div>
                                 <div class="text-lg font-semibold" id="planName">Free Plan</div>
-                                <div class="text-sm text-gray-600 dark:text-gray-400" id="planDescription">Basic domino game tracking</div>
+                                <div class="text-sm text-gray-600 dark:text-white" id="planDescription">Basic domino game tracking</div>
                             </div>
                             <div class="text-right">
                                 <div class="text-lg font-bold" id="planPrice">$0/month</div>
-                                <div class="text-sm text-gray-600 dark:text-gray-400" id="planStatus">Active</div>
+                                <div class="text-sm text-gray-600 dark:text-white" id="planStatus">Active</div>
                             </div>
                         </div>
                         


### PR DESCRIPTION
## Summary
- style billing section for dark mode with gray background and white text

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7b675e1c8326a55af1e4b227a2ea