### PR TITLE
feat: style billing section for dark mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -750,10 +750,10 @@
 
         <!-- Billing Section -->
         <div id="billingSection" class="section hidden">
-            <div class="max-w-4xl mx-auto">
+            <div class="max-w-4xl mx-auto domino-card p-6">
                 <div class="mb-6">
                     <h2 class="text-2xl font-bold mb-2">Subscription & Billing</h2>
-                    <p class="text-gray-600 dark:text-gray-400">Manage your Domino Score Pro subscription</p>
+                    <p class="text-gray-600 dark:text-white">Manage your Domino Score Pro subscription</p>
                 </div>
 
                 <!-- Current Plan -->
@@ -763,11 +763,11 @@
                         <div class="flex items-center justify-between">
                             <div>
                                 <div class="text-lg font-semibold" id="planName">Free Plan</div>
-                                <div class="text-sm text-gray-600 dark:text-gray-400" id="planDescription">Basic domino game tracking</div>
+                                <div class="text-sm text-gray-600 dark:text-white" id="planDescription">Basic domino game tracking</div>
                             </div>
                             <div class="text-right">
                                 <div class="text-lg font-bold" id="planPrice">$0/month</div>
-                                <div class="text-sm text-gray-600 dark:text-gray-400" id="planStatus">Active</div>
+                                <div class="text-sm text-gray-600 dark:text-white" id="planStatus">Active</div>
                             </div>
                         </div>
                         


### PR DESCRIPTION
## Summary
- style billing section container with `domino-card` for dark mode consistency
- ensure billing text renders white in dark mode

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7b675e1c8326a55af1e4b227a2ea