### PR TITLE
feat: Update dropdown button styles to be inverted

### DIFF
--- a/index.html
+++ b/index.html
@@ -184,6 +184,21 @@
             border-radius: 8px;
         }
 
+        .inverted-dropdown-button {
+            background-color: #1f2937; /* bg-gray-900 */
+            color: white;
+            transition: background-color 0.2s;
+        }
+        .inverted-dropdown-button:hover {
+            background-color: #374151; /* bg-gray-700 */
+        }
+        .dark .inverted-dropdown-button {
+            background-color: #374151; /* bg-gray-700 */
+        }
+        .dark .inverted-dropdown-button:hover {
+            background-color: #4b5563; /* bg-gray-600 */
+        }
+
         .dark .mobile-nav-btn.active {
             color: #60a5fa; /* Lighter blue for dark mode */
             background-color: #374151; /* Contrasting dark gray */
@@ -279,10 +294,10 @@
                         </button>
                         <div id="userDropdown" class="hidden absolute right-0 mt-2 w-48 bg-white dark:bg-gray-800 rounded-lg shadow-lg border dark:border-gray-700 z-50">
                             <div class="py-2">
-                                <button onclick="showBilling()" class="w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700">
+                                <button onclick="showBilling()" class="w-full text-left px-4 py-2 text-sm inverted-dropdown-button">
                                     <i class="fas fa-credit-card mr-2"></i>Billing
                                 </button>
-                                <button onclick="handleSignOut()" class="w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700">
+                                <button onclick="handleSignOut()" class="w-full text-left px-4 py-2 text-sm inverted-dropdown-button">
                                     <i class="fas fa-sign-out-alt mr-2"></i>Sign Out
                                 </button>
                             </div>


### PR DESCRIPTION
This commit introduces a new CSS class, `inverted-dropdown-button`, to restyle the 'Billing' and 'Sign Out' buttons in the user dropdown menu.

The new style gives the buttons a dark background and light text, with a slightly lighter background on hover, for both light and dark modes. This addresses the user's request for an inverted color scheme on these specific buttons.