### PR TITLE
fix(leaderboard): Default to current week in weekly leaderboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -2926,13 +2926,22 @@
 
             const weeks = buildWeeksForMonth(now.getFullYear(), now.getMonth());
             weekSelect.innerHTML = weeks.map((w, i) => `<option value="${i}">${w.label}</option>`).join('');
-            weekSelect.value = '0';
+
+            // Find and select the current week by default
+            let currentWeekIndex = 0;
+            for (let i = 0; i < weeks.length; i++) {
+                if (now >= weeks[i].start && now <= weeks[i].end) {
+                    currentWeekIndex = i;
+                    break;
+                }
+            }
+            weekSelect.value = currentWeekIndex;
 
             monthSelect.onchange = () => {
                 const [y, m] = monthSelect.value.split('-').map(Number);
                 const monthWeeks = buildWeeksForMonth(y, m - 1);
                 weekSelect.innerHTML = monthWeeks.map((w, i) => `<option value="${i}">${w.label}</option>`).join('');
-                weekSelect.value = '0';
+                weekSelect.value = '0'; // When month changes, default to the first week.
                 showLeaderboard('weekly');
             };
             weekSelect.onchange = () => showLeaderboard('weekly');


### PR DESCRIPTION
The weekly leaderboard was always defaulting to the first week of the selected month. This change updates the logic to find the current week based on the current date and sets it as the default selection. When viewing a different month, it correctly continues to default to the first week of that month.