### PR TITLE
feat: Prevent same player from being selected twice

### DIFF
--- a/api/games/index.ts
+++ b/api/games/index.ts
@@ -119,6 +119,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           return res.status(400).json({ error: 'Game type and players are required' });
         }
 
+        // Check for duplicate players
+        const uniquePlayers = new Set(players);
+        if (uniquePlayers.size !== players.length) {
+          return res.status(400).json({ error: 'The same player cannot be selected for both sides of the game.' });
+        }
+
         const gameData = {
           user_id: user.id,
           game_type: gameType,


### PR DESCRIPTION
Adds a check to the create game API endpoint to prevent the same player from being selected for both sides of a game.

When a new game is being created, the `players` array is now checked for duplicate entries. If any duplicates are found, the API returns a 400 Bad Request error with a message indicating that the same player cannot be selected twice.