### PR TITLE
Fix API routes, env fallbacks, games pagination and team player resolution

### DIFF
--- a/api/auth/google.ts
+++ b/api/auth/google.ts
@@ -2,8 +2,8 @@ import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { createClient } from '@supabase/supabase-js';
 
 const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE!
+  (process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL)!,
+  (process.env.SUPABASE_SERVICE_ROLE || process.env.SUPABASE_SERVICE_ROLE_KEY)!
 );
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {

--- a/api/auth/index.ts
+++ b/api/auth/index.ts
@@ -2,8 +2,8 @@ import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { createClient } from '@supabase/supabase-js';
 
 const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE!
+  (process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL)!,
+  (process.env.SUPABASE_SERVICE_ROLE || process.env.SUPABASE_SERVICE_ROLE_KEY)!
 );
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {

--- a/api/auth/session-management.ts
+++ b/api/auth/session-management.ts
@@ -2,8 +2,8 @@ import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { createClient } from '@supabase/supabase-js';
 
 const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE!
+  (process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL)!,
+  (process.env.SUPABASE_SERVICE_ROLE || process.env.SUPABASE_SERVICE_ROLE_KEY)!
 );
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {

--- a/api/auth/session.ts
+++ b/api/auth/session.ts
@@ -1,0 +1,1 @@
+export { default } from './session-management';

--- a/api/checkout.ts
+++ b/api/checkout.ts
@@ -1,0 +1,27 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import Stripe from 'stripe';
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, { apiVersion: '2024-12-18.acacia' });
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  try {
+    const { priceId, customerEmail, successUrl, cancelUrl, clientReferenceId } = req.body || {};
+
+    const session = await stripe.checkout.sessions.create({
+      mode: 'subscription',
+      customer_email: customerEmail,
+      line_items: [{ price: priceId ?? process.env.NEXT_PUBLIC_PRICE_PRO!, quantity: 1 }],
+      success_url: successUrl ?? `${process.env.NEXT_PUBLIC_APP_URL ?? 'https://domino-score.vercel.app'}/billing/success`,
+      cancel_url: cancelUrl ?? `${process.env.NEXT_PUBLIC_APP_URL ?? 'https://domino-score.vercel.app'}/billing`,
+      client_reference_id: clientReferenceId ?? undefined,
+    });
+
+    return res.status(200).json({ url: session.url });
+  } catch (error: any) {
+    return res.status(400).json({ error: error.message });
+  }
+}

--- a/api/games/index.ts
+++ b/api/games/index.ts
@@ -2,8 +2,8 @@ import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { createClient } from '@supabase/supabase-js';
 
 const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE!
+  (process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL)!,
+  (process.env.SUPABASE_SERVICE_ROLE || process.env.SUPABASE_SERVICE_ROLE_KEY)!
 );
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
@@ -91,13 +91,15 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       if (req.method === 'GET') {
         // Get user's games
         const { type, limit = 20, offset = 0 } = req.query;
+        const parsedLimit = Math.max(1, Math.min(100, Number(limit) || 20));
+        const parsedOffset = Math.max(0, Number(offset) || 0);
 
         let query = supabase
           .from('games')
           .select('*')
           .eq('user_id', user.id)
           .order('created_at', { ascending: false })
-          .range(offset as number, (offset as number) + (limit as number) - 1);
+          .range(parsedOffset, parsedOffset + parsedLimit - 1);
 
         if (type) {
           query = query.eq('game_type', type);
@@ -115,14 +117,32 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         // Create a new game
         const { gameType, players, initialData, teamId } = req.body;
 
-        if (!gameType || !players || !Array.isArray(players) || players.length === 0) {
-          return res.status(400).json({ error: 'Game type and players are required' });
+        if (!gameType) {
+          return res.status(400).json({ error: 'Game type is required' });
+        }
+
+        let resolvedPlayers = players;
+
+        // Team games can derive players automatically from active team memberships.
+        if ((!resolvedPlayers || !Array.isArray(resolvedPlayers) || resolvedPlayers.length === 0) && teamId) {
+          const { data: teamMembers, error: teamMembersError } = await supabase
+            .rpc('get_team_members', { team_uuid: teamId as string });
+
+          if (teamMembersError) {
+            return res.status(500).json({ error: 'Failed to load team members for game' });
+          }
+
+          resolvedPlayers = (teamMembers || []).filter((member: any) => member.is_active !== false);
+        }
+
+        if (!Array.isArray(resolvedPlayers) || resolvedPlayers.length === 0) {
+          return res.status(400).json({ error: 'Players are required (or provide a valid teamId)' });
         }
 
         const gameData = {
           user_id: user.id,
           game_type: gameType,
-          players: players,
+          players: resolvedPlayers,
           scores: initialData?.scores || {},
           completed: false,
           created_at: new Date().toISOString(),

--- a/api/leaderboard.ts
+++ b/api/leaderboard.ts
@@ -2,8 +2,8 @@ import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { createClient } from '@supabase/supabase-js';
 
 const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE!
+  (process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL)!,
+  (process.env.SUPABASE_SERVICE_ROLE || process.env.SUPABASE_SERVICE_ROLE_KEY)!
 );
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {

--- a/api/portal.ts
+++ b/api/portal.ts
@@ -1,0 +1,26 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import Stripe from 'stripe';
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, { apiVersion: '2024-12-18.acacia' });
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const { customerId } = req.body || {};
+  if (!customerId) {
+    return res.status(400).json({ error: 'Missing customerId' });
+  }
+
+  try {
+    const session = await stripe.billingPortal.sessions.create({
+      customer: customerId,
+      return_url: `${process.env.NEXT_PUBLIC_APP_URL ?? 'https://domino-score.vercel.app'}/billing`,
+    });
+
+    return res.status(200).json({ url: session.url });
+  } catch (error: any) {
+    return res.status(400).json({ error: error.message });
+  }
+}

--- a/api/stripe-webhook.ts
+++ b/api/stripe-webhook.ts
@@ -10,7 +10,7 @@ export const config = {
 };
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, { apiVersion: '2024-12-18.acacia' });
-const supabase = createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE!);
+const supabase = createClient((process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL)!, (process.env.SUPABASE_SERVICE_ROLE || process.env.SUPABASE_SERVICE_ROLE_KEY)!);
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'POST') return res.status(405).end('Method Not Allowed');

--- a/api/teams/[id].ts
+++ b/api/teams/[id].ts
@@ -2,8 +2,8 @@ import { createClient } from '@supabase/supabase-js';
 import jwt from 'jsonwebtoken';
 
 const supabase = createClient(
-  process.env.SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!
+  (process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL)!,
+  (process.env.SUPABASE_SERVICE_ROLE || process.env.SUPABASE_SERVICE_ROLE_KEY)!
 );
 
 interface TeamUpdateRequest {
@@ -35,7 +35,7 @@ export default async function handler(req: any, res: any) {
     let decoded: any;
     
     try {
-      decoded = jwt.verify(token, process.env.SUPABASE_JWT_SECRET!);
+      decoded = jwt.verify(token, (process.env.SUPABASE_JWT_SECRET || process.env.JWT_SECRET)!);
     } catch (error) {
       return res.status(401).json({ error: 'Invalid token' });
     }

--- a/api/teams/[id]/members.ts
+++ b/api/teams/[id]/members.ts
@@ -2,8 +2,8 @@ import { createClient } from '@supabase/supabase-js';
 import jwt from 'jsonwebtoken';
 
 const supabase = createClient(
-  process.env.SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!
+  (process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL)!,
+  (process.env.SUPABASE_SERVICE_ROLE || process.env.SUPABASE_SERVICE_ROLE_KEY)!
 );
 
 interface AddMemberRequest {
@@ -37,7 +37,7 @@ export default async function handler(req: any, res: any) {
     let decoded: any;
     
     try {
-      decoded = jwt.verify(token, process.env.SUPABASE_JWT_SECRET!);
+      decoded = jwt.verify(token, (process.env.SUPABASE_JWT_SECRET || process.env.JWT_SECRET)!);
     } catch (error) {
       return res.status(401).json({ error: 'Invalid token' });
     }

--- a/api/teams/index.ts
+++ b/api/teams/index.ts
@@ -2,8 +2,8 @@ import { createClient } from '@supabase/supabase-js';
 import jwt from 'jsonwebtoken';
 
 const supabase = createClient(
-  process.env.SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!
+  (process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL)!,
+  (process.env.SUPABASE_SERVICE_ROLE || process.env.SUPABASE_SERVICE_ROLE_KEY)!
 );
 
 interface TeamCreateRequest {
@@ -42,7 +42,7 @@ export default async function handler(req: any, res: any) {
     let decoded: any;
     
     try {
-      decoded = jwt.verify(token, process.env.SUPABASE_JWT_SECRET!);
+      decoded = jwt.verify(token, (process.env.SUPABASE_JWT_SECRET || process.env.JWT_SECRET)!);
     } catch (error) {
       return res.status(401).json({ error: 'Invalid token' });
     }

--- a/api/users/profile.ts
+++ b/api/users/profile.ts
@@ -2,8 +2,8 @@ import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { createClient } from '@supabase/supabase-js';
 
 const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE!
+  (process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL)!,
+  (process.env.SUPABASE_SERVICE_ROLE || process.env.SUPABASE_SERVICE_ROLE_KEY)!
 );
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {


### PR DESCRIPTION
### Motivation
- The frontend expected several API endpoints and consistent environment keys that were missing or mismatched, causing runtime failures when the UI attempted billing, session, team and game operations. 
- `POST /api/games` required explicit `players` and did not support deriving players from a `teamId`, which broke team-based workflows and tests. 
- Numeric query params for pagination were used raw, which can cause invalid ranges and runtime errors. 

### Description
- Added a lightweight `api/auth/session.ts` that re-exports the existing session management handler to provide `/api/auth/session`. 
- Added dedicated `api/checkout.ts` and `api/portal.ts` endpoints to match the frontend billing calls and keep billing flows separate from the action-based `api/billing.ts`. 
- Made Supabase client initialization resilient to env-name differences by accepting `NEXT_PUBLIC_SUPABASE_URL` or `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE` or `SUPABASE_SERVICE_ROLE_KEY` across API handlers. 
- Made team JWT verification resilient to either `SUPABASE_JWT_SECRET` or `JWT_SECRET`. 
- Improved `GET /api/games` pagination by parsing and clamping `limit`/`offset` into numeric values before calling `.range(...)`. 
- Updated `POST /api/games` to auto-resolve `players` from active team memberships when `teamId` is provided and `players` is omitted. 
- Updated the Stripe webhook handler to use the same Supabase env fallback approach. 

### Testing
- Ran `npm run build`, which completed successfully. 
- Ran `npm test`, which failed because this repository contains no configured test suite (`test` script intentionally exits with an error). 
- Attempted dependency installation and TypeScript validation but `npm install` failed with a `403 Forbidden` from the registry and earlier `tsc` checks reported missing type libs, so full compile-time validation could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b458f5d46c8326bfa23d1c52b103d5)